### PR TITLE
Fix `setKernelMacServer` NetworkServiceServer chain element and add tests to cover

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
         with:
           go-version: 1.13
       - name: Install go-header
-        run: 'go get github.com/denis-tingajkin/go-header@v0.2.1'
+        run: 'go get github.com/denis-tingajkin/go-header@v0.2.2'
       - name: Run go-header
         run: |
           eval $(go env)

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.4.2
+	github.com/stretchr/testify v1.4.0
 	google.golang.org/grpc v1.26.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/pkg/networkservice/connectioncontext/client.go
+++ b/pkg/networkservice/connectioncontext/client.go
@@ -17,8 +17,9 @@
 package connectioncontext
 
 import (
-	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
+
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
 
 	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/connectioncontext/ethernetcontext/macaddress"
 	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/connectioncontext/ipcontext/ipaddress"

--- a/pkg/networkservice/connectioncontext/server.go
+++ b/pkg/networkservice/connectioncontext/server.go
@@ -19,8 +19,9 @@
 package connectioncontext
 
 import (
-	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
+
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
 
 	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/connectioncontext/ethernetcontext/macaddress"
 	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/connectioncontext/ipcontext/ipaddress"

--- a/pkg/networkservice/connectioncontextkernel/client.go
+++ b/pkg/networkservice/connectioncontextkernel/client.go
@@ -19,8 +19,9 @@
 package connectioncontextkernel
 
 import (
-	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
+
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
 
 	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/connectioncontextkernel/ipcontext/ipaddress"
 )

--- a/pkg/networkservice/connectioncontextkernel/client.go
+++ b/pkg/networkservice/connectioncontextkernel/client.go
@@ -22,7 +22,6 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 
-	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/connectioncontextkernel/ethernetcontext/macaddress"
 	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/connectioncontextkernel/ipcontext/ipaddress"
 )
 
@@ -52,6 +51,5 @@ import (
 func NewClient() networkservice.NetworkServiceClient {
 	return chain.NewNetworkServiceClient(
 		ipaddress.NewClient(),
-		macaddress.NewClient(),
 	)
 }

--- a/pkg/networkservice/connectioncontextkernel/ethernetcontext/macaddress/client_test.go
+++ b/pkg/networkservice/connectioncontextkernel/ethernetcontext/macaddress/client_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package macaddress
+
+import (
+	"context"
+	"github.com/ligato/vpp-agent/api/models/linux"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/kernel"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connectioncontext"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
+	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/vppagent"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestClientBasic(t *testing.T) {
+	ctx := vppagent.WithConfig(context.Background())
+	config := vppagent.Config(ctx)
+	config.LinuxConfig = &linux.ConfigData{
+		Interfaces: []*linux.Interface{
+			{
+				Name: "SRC-1",
+			},
+		},
+	}
+	request := &networkservice.NetworkServiceRequest{
+		Connection: &connection.Connection{
+			Id: "1",
+			Mechanism: &connection.Mechanism{
+				Type: kernel.MECHANISM,
+			},
+			Context: &connectioncontext.ConnectionContext{
+				EthernetContext: &connectioncontext.EthernetContext{
+					DstMac: "0a-1b-3c-4d-5e-6f",
+				},
+			},
+		},
+	}
+	server := next.NewNetworkServiceServer(NewServer())
+	cc, err := server.Request(ctx, request)
+	assert.NoError(t, err)
+	assert.NotNil(t, cc)
+	assert.NotEqual(t, nil, cc)
+	for _, iface := range config.LinuxConfig.Interfaces {
+		if iface.Name == "SRC-"+request.Connection.Id {
+			assert.Equal(t, iface.PhysAddress, request.Connection.Context.EthernetContext.DstMac)
+			return
+		}
+	}
+	assert.FailNow(t, "interface SRC-1 not found in vpp-config")
+}

--- a/pkg/networkservice/connectioncontextkernel/ethernetcontext/macaddress/server.go
+++ b/pkg/networkservice/connectioncontextkernel/ethernetcontext/macaddress/server.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
 // Copyright (c) 2020 Cisco Systems, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -19,7 +21,6 @@ package macaddress
 
 import (
 	"context"
-
 	"github.com/golang/protobuf/ptypes/empty"
 
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection"
@@ -31,7 +32,7 @@ import (
 	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/vppagent"
 )
 
-type setVppMacServer struct{}
+type setKernelMacServer struct{}
 
 // NewServer creates a NetworkServiceServer chain element to set the mac address on a kernel interface
 // It sets the Mac Address on the *kernel* side of an interface plugged into the
@@ -57,26 +58,25 @@ type setVppMacServer struct{}
 //                              +---------------------------+
 //
 func NewServer() networkservice.NetworkServiceServer {
-	return &setVppMacServer{}
+	return &setKernelMacServer{}
 }
 
-func (s *setVppMacServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*connection.Connection, error) {
-	conf := vppagent.Config(ctx)
-	conn, err := next.Client(ctx).Request(ctx, request)
-	if err != nil {
-		return nil, err
-	}
+func (s *setKernelMacServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*connection.Connection, error) {
 	if mechanism := kernel.ToMechanism(request.GetConnection().GetMechanism()); mechanism != nil {
-		index := len(conf.GetLinuxConfig().GetInterfaces()) - 1
-		conf.GetLinuxConfig().GetInterfaces()[index+1].PhysAddress = conn.GetContext().GetEthernetContext().GetDstMac()
+		s.setDstMac(ctx, request.GetConnection())
 	}
-	return conn, nil
+	return next.Server(ctx).Request(ctx, request)
 }
 
-func (s *setVppMacServer) Close(ctx context.Context, conn *connection.Connection) (*empty.Empty, error) {
-	conf := vppagent.Config(ctx)
-	if mechanism := kernel.ToMechanism(conn.GetMechanism()); mechanism != nil && len(conf.GetLinuxConfig().GetInterfaces()) > 0 {
-		conf.GetLinuxConfig().GetInterfaces()[len(conf.GetVppConfig().GetInterfaces())-1].PhysAddress = conn.GetContext().GetEthernetContext().GetDstMac()
+func (s *setKernelMacServer) Close(ctx context.Context, conn *connection.Connection) (*empty.Empty, error) {
+	if mechanism := kernel.ToMechanism(conn.GetMechanism()); mechanism != nil {
+		s.setDstMac(ctx, conn)
 	}
-	return next.Client(ctx).Close(ctx, conn)
+	return next.Server(ctx).Close(ctx, conn)
+}
+
+func (s *setKernelMacServer) setDstMac(ctx context.Context, conn *connection.Connection) {
+	config := vppagent.Config(ctx)
+	current := len(config.LinuxConfig.Interfaces) - 1
+	config.LinuxConfig.Interfaces[current].PhysAddress = conn.GetContext().GetEthernetContext().DstMac
 }

--- a/pkg/networkservice/connectioncontextkernel/ethernetcontext/macaddress/server_test.go
+++ b/pkg/networkservice/connectioncontextkernel/ethernetcontext/macaddress/server_test.go
@@ -20,28 +20,20 @@ import (
 	"context"
 	"testing"
 
+	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/ligato/vpp-agent/api/models/linux"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/vppagent"
 
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/kernel"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connectioncontext"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
+
+	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/vppagent"
 )
 
 func TestServerBasic(t *testing.T) {
-	ctx := vppagent.WithConfig(context.Background())
-	config := vppagent.Config(ctx)
-	config.LinuxConfig = &linux.ConfigData{
-		Interfaces: []*linux.Interface{
-			{
-				Name: "DST-1",
-			},
-		},
-	}
 	request := &networkservice.NetworkServiceRequest{
 		Connection: &connection.Connection{
 			Id: "1",
@@ -55,16 +47,45 @@ func TestServerBasic(t *testing.T) {
 			},
 		},
 	}
-	server := next.NewNetworkServiceServer(NewServer())
-	cc, err := server.Request(ctx, request)
-	assert.NoError(t, err)
-	assert.NotNil(t, cc)
-	assert.NotEqual(t, nil, cc)
-	for _, iface := range config.LinuxConfig.Interfaces {
-		if iface.Name == "DST-"+request.Connection.Id {
-			assert.Equal(t, iface.PhysAddress, request.Connection.Context.EthernetContext.DstMac)
-			return
-		}
+	server := next.NewNetworkServiceServer(vppagent.NewServer(), &testingServer{t}, NewServer())
+	_, _ = server.Request(context.Background(), request)
+	_, _ = server.Close(context.Background(), request.Connection)
+}
+
+type testingServer struct {
+	*testing.T
+}
+
+func (t *testingServer) Request(ctx context.Context, in *networkservice.NetworkServiceRequest) (*connection.Connection, error) {
+	config := vppagent.Config(ctx)
+	assert.NotNil(t, config)
+	targetInterface := &linux.Interface{
+		Name: "DST-1",
 	}
-	assert.FailNow(t, "interface DST-1 not found in vpp-config")
+	config.LinuxConfig = &linux.ConfigData{
+		Interfaces: []*linux.Interface{
+			targetInterface,
+		},
+	}
+	conn, err := next.Server(ctx).Request(ctx, in)
+	assert.Nil(t, err)
+	assert.Equal(t, targetInterface.PhysAddress, conn.GetContext().GetEthernetContext().GetDstMac())
+	return conn, err
+}
+
+func (t *testingServer) Close(ctx context.Context, conn *connection.Connection) (*empty.Empty, error) {
+	config := vppagent.Config(ctx)
+	assert.NotNil(t, config)
+	targetInterface := &linux.Interface{
+		Name: "DST-1",
+	}
+	config.LinuxConfig = &linux.ConfigData{
+		Interfaces: []*linux.Interface{
+			targetInterface,
+		},
+	}
+	result, err := next.Server(ctx).Close(ctx, conn)
+	assert.Nil(t, err)
+	assert.Equal(t, targetInterface.PhysAddress, conn.GetContext().GetEthernetContext().GetDstMac())
+	return result, err
 }

--- a/pkg/networkservice/connectioncontextkernel/ethernetcontext/macaddress/server_test.go
+++ b/pkg/networkservice/connectioncontextkernel/ethernetcontext/macaddress/server_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package macaddress
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ligato/vpp-agent/api/models/linux"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/vppagent"
+
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/kernel"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connectioncontext"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
+)
+
+func TestServerBasic(t *testing.T) {
+	ctx := vppagent.WithConfig(context.Background())
+	config := vppagent.Config(ctx)
+	config.LinuxConfig = &linux.ConfigData{
+		Interfaces: []*linux.Interface{
+			{
+				Name: "DST-1",
+			},
+		},
+	}
+	request := &networkservice.NetworkServiceRequest{
+		Connection: &connection.Connection{
+			Id: "1",
+			Mechanism: &connection.Mechanism{
+				Type: kernel.MECHANISM,
+			},
+			Context: &connectioncontext.ConnectionContext{
+				EthernetContext: &connectioncontext.EthernetContext{
+					DstMac: "0a-1b-3c-4d-5e-6f",
+				},
+			},
+		},
+	}
+	server := next.NewNetworkServiceServer(NewServer())
+	cc, err := server.Request(ctx, request)
+	assert.NoError(t, err)
+	assert.NotNil(t, cc)
+	assert.NotEqual(t, nil, cc)
+	for _, iface := range config.LinuxConfig.Interfaces {
+		if iface.Name == "DST-"+request.Connection.Id {
+			assert.Equal(t, iface.PhysAddress, request.Connection.Context.EthernetContext.DstMac)
+			return
+		}
+	}
+	assert.FailNow(t, "interface DST-1 not found in vpp-config")
+}

--- a/pkg/networkservice/connectioncontextkernel/ipcontext/routes/server.go
+++ b/pkg/networkservice/connectioncontextkernel/ipcontext/routes/server.go
@@ -24,10 +24,11 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/ligato/vpp-agent/api/models/linux"
 	linuxl3 "github.com/ligato/vpp-agent/api/models/linux/l3"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/kernel"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 
 	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/vppagent"
 )

--- a/pkg/networkservice/connectioncontextkernel/server.go
+++ b/pkg/networkservice/connectioncontextkernel/server.go
@@ -17,8 +17,9 @@
 package connectioncontextkernel
 
 import (
-	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
+
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
 
 	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/connectioncontextkernel/ethernetcontext/macaddress"
 	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/connectioncontextkernel/ipcontext/ipaddress"

--- a/pkg/networkservice/mechanisms/kernel/kerneltap/client.go
+++ b/pkg/networkservice/mechanisms/kernel/kerneltap/client.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/cls"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/common"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/kernel"
-	"github.com/pkg/errors"
-	"google.golang.org/grpc"
 
 	"github.com/networkservicemesh/sdk-vppagent/pkg/tools/netnsinode"
 

--- a/pkg/networkservice/mechanisms/kernel/kernelvethpair/client.go
+++ b/pkg/networkservice/mechanisms/kernel/kernelvethpair/client.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/cls"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/common"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/cls"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/common"
 
 	"github.com/networkservicemesh/sdk-vppagent/pkg/tools/netnsinode"
 

--- a/pkg/networkservice/vppagent/client.go
+++ b/pkg/networkservice/vppagent/client.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
 // Copyright (c) 2020 Cisco Systems, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -17,12 +19,27 @@
 package vppagent
 
 import (
-	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
+	"context"
 
-	"github.com/networkservicemesh/sdk/pkg/networkservice/core/adapters"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
 )
+
+type configClient struct{}
+
+func (c configClient) Request(ctx context.Context, in *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*connection.Connection, error) {
+	return next.Client(ctx).Request(withConfig(ctx), in, opts...)
+}
+
+func (c configClient) Close(ctx context.Context, in *connection.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
+	return next.Client(ctx).Close(withConfig(ctx), in, opts...)
+}
 
 // NewClient - inserts a vppagent *configurator.Config into the GRPC call context.Context
 func NewClient() networkservice.NetworkServiceClient {
-	return adapters.NewServerToClient(&configServer{})
+	return &configClient{}
 }

--- a/pkg/networkservice/vppagent/context.go
+++ b/pkg/networkservice/vppagent/context.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
-//
 // Copyright (c) 2020 Cisco Systems, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -34,8 +32,8 @@ const (
 	configKey contextKeyType = "configKey"
 )
 
-// WithConfig gets vppagent config from context
-func WithConfig(ctx context.Context) context.Context {
+// withConfig gets vppagent config from context
+func withConfig(ctx context.Context) context.Context {
 	if config, ok := ctx.Value(configKey).(*configurator.Config); ok && config != nil {
 		return ctx
 	}

--- a/pkg/networkservice/vppagent/context.go
+++ b/pkg/networkservice/vppagent/context.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
 // Copyright (c) 2020 Cisco Systems, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -33,7 +35,7 @@ const (
 )
 
 // WithConfig gets vppagent config from context
-func withConfig(ctx context.Context) context.Context {
+func WithConfig(ctx context.Context) context.Context {
 	if config, ok := ctx.Value(configKey).(*configurator.Config); ok && config != nil {
 		return ctx
 	}

--- a/pkg/networkservice/vppagent/server.go
+++ b/pkg/networkservice/vppagent/server.go
@@ -35,9 +35,9 @@ func NewServer() networkservice.NetworkServiceServer {
 }
 
 func (c *configServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*connection.Connection, error) {
-	return next.Server(ctx).Request(WithConfig(ctx), request)
+	return next.Server(ctx).Request(withConfig(ctx), request)
 }
 
 func (c *configServer) Close(ctx context.Context, conn *connection.Connection) (*empty.Empty, error) {
-	return next.Server(ctx).Close(WithConfig(ctx), conn)
+	return next.Server(ctx).Close(withConfig(ctx), conn)
 }

--- a/pkg/networkservice/vppagent/server.go
+++ b/pkg/networkservice/vppagent/server.go
@@ -35,9 +35,9 @@ func NewServer() networkservice.NetworkServiceServer {
 }
 
 func (c *configServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*connection.Connection, error) {
-	return next.Server(ctx).Request(withConfig(ctx), request)
+	return next.Server(ctx).Request(WithConfig(ctx), request)
 }
 
 func (c *configServer) Close(ctx context.Context, conn *connection.Connection) (*empty.Empty, error) {
-	return next.Server(ctx).Close(withConfig(ctx), conn)
+	return next.Server(ctx).Close(WithConfig(ctx), conn)
 }


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

The first part of splitting PR https://github.com/networkservicemesh/sdk-vppagent/pull/38