### PR TITLE
Extract doc.go file to make pkg xconnects compilable under windows

### DIFF
--- a/pkg/networkservice/chains/xconnectns/doc.go
+++ b/pkg/networkservice/chains/xconnectns/doc.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package xconnectns provides an Endpoint that implements the cross connect networks service for use as a Forwarder
+package xconnectns

--- a/pkg/networkservice/chains/xconnectns/server.go
+++ b/pkg/networkservice/chains/xconnectns/server.go
@@ -16,7 +16,6 @@
 
 // +build !windows
 
-// Package xconnectns provides an Endpoint that implements the cross connect networks service for use as a Forwarder
 package xconnectns
 
 import (


### PR DESCRIPTION
Currently, cmd-forwarder-vppagent is not compilable under windows by this error
```
go\src\github.com\networkservicemesh\cmd-forwarder-vppagent> go build ./...
build github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/chains/xconnectns: cannot load github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/chains/xconnectns: no Go source files
```
Related to this line https://github.com/networkservicemesh/cmd-forwarder-vppagent/blob/master/internal/imports/imports.go#L15
This PR just moves doc part to separate file that makes pkg xconnects compilable under windows.