### PR TITLE
Change position of directMemifServer in xconnectNSServer chain

### DIFF
--- a/pkg/networkservice/chains/xconnectns/server.go
+++ b/pkg/networkservice/chains/xconnectns/server.go
@@ -23,6 +23,8 @@ import (
 	"net"
 	"net/url"
 
+	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/mechanisms/directmemif"
+
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 
@@ -32,8 +34,6 @@ import (
 	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/metrics"
 
 	"go.ligato.io/vpp-agent/v3/proto/ligato/configurator"
-
-	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/mechanisms/directmemif"
 
 	"google.golang.org/grpc"
 
@@ -74,7 +74,6 @@ func NewServer(ctx context.Context, name string, authzServer networkservice.Netw
 		tokenGenerator,
 		// Make sure we have a fresh empty config for everyone in the chain to use
 		vppagent.NewServer(),
-		directmemif.NewServer(),
 		mechanisms.NewServer(map[string]networkservice.NetworkServiceServer{
 			memif.MECHANISM:  memif.NewServer(baseDir),
 			kernel.MECHANISM: kernel.NewServer(),
@@ -102,6 +101,7 @@ func NewServer(ctx context.Context, name string, authzServer networkservice.Netw
 			clientDialOptions...,
 		),
 		connectioncontextkernel.NewServer(),
+		directmemif.NewServer(),
 		metrics.NewServer(configurator.NewStatsPollerServiceClient(vppagentCC)),
 		commit.NewServer(vppagentCC),
 	)

--- a/pkg/networkservice/chains/xconnectns/server.go
+++ b/pkg/networkservice/chains/xconnectns/server.go
@@ -23,6 +23,9 @@ import (
 	"net"
 	"net/url"
 
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/adapters"
+	"github.com/networkservicemesh/sdk/pkg/tools/addressof"
+
 	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/mechanisms/directmemif"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
@@ -41,8 +44,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clienturl"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/core/adapters"
-	"github.com/networkservicemesh/sdk/pkg/tools/addressof"
 
 	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/commit"
 	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/mechanisms/kernel"

--- a/pkg/networkservice/chains/xconnectns/server_test.go
+++ b/pkg/networkservice/chains/xconnectns/server_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package xconnectns_test
+
+import (
+	"context"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/cls"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/memif"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/checks/checkcontext"
+	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
+	"github.com/stretchr/testify/require"
+	"go.ligato.io/vpp-agent/v3/proto/ligato/configurator"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/chains/xconnectns"
+	memif_mechanism "github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/mechanisms/memif"
+	"github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/vppagent"
+)
+
+const (
+	anyPortLocalHost string = "127.0.0.1:0"
+	sourceSocketFile string = "source.sock"
+	targetSocketFile string = "target.sock"
+)
+
+type fakeVppAgent struct {
+	configurator.ConfiguratorServiceServer
+}
+
+type fakeNSM struct {
+}
+
+func (fva *fakeVppAgent) Update(ctx context.Context, in *configurator.UpdateRequest) (*configurator.UpdateResponse, error) {
+	return &configurator.UpdateResponse{}, nil
+}
+
+func (fn *fakeNSM) Request(ctx context.Context, req *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	req.Connection.Mechanism = &networkservice.Mechanism{
+		Cls:  cls.LOCAL,
+		Type: memif_mechanism.MECHANISM,
+		Parameters: map[string]string{
+			memif.SocketFilename: targetSocketFile,
+		},
+	}
+
+	return req.Connection, nil
+}
+
+func (fn *fakeNSM) Close(context.Context, *networkservice.Connection) (*empty.Empty, error) {
+	return nil, nil
+}
+
+func request(t *testing.T) *networkservice.NetworkServiceRequest {
+	expires, err := ptypes.TimestampProto(time.Now().Add(time.Hour))
+	require.NoError(t, err)
+
+	return &networkservice.NetworkServiceRequest{
+		Connection: &networkservice.Connection{
+			Mechanism: &networkservice.Mechanism{
+				Cls:  cls.LOCAL,
+				Type: memif_mechanism.MECHANISM,
+				Parameters: map[string]string{
+					memif.SocketFilename: sourceSocketFile,
+				},
+			},
+			Path: &networkservice.Path{
+				Index: 0,
+				PathSegments: []*networkservice.PathSegment{
+					{
+						Expires: expires,
+					},
+				},
+			},
+		},
+	}
+}
+
+func fakeVppClientConn(ctx context.Context, t *testing.T, css configurator.ConfiguratorServiceServer) grpc.ClientConnInterface {
+	s := grpc.NewServer()
+	configurator.RegisterConfiguratorServiceServer(s, css)
+
+	vppURL := &url.URL{Scheme: "tcp", Host: anyPortLocalHost}
+	grpcutils.ListenAndServe(ctx, vppURL, s)
+
+	clientConn, err := grpc.Dial(vppURL.Host, grpc.WithInsecure())
+	require.NoError(t, err)
+	return clientConn
+}
+
+func tokenGenerator(peerAuthInfo credentials.AuthInfo) (tokenValue string, expireTime time.Time, err error) {
+	return "TestToken", time.Date(3000, 1, 1, 1, 1, 1, 1, time.UTC), nil
+}
+
+func TestDirectMemifCase(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*2))
+	defer cancel()
+
+	dir, err := ioutil.TempDir(os.TempDir(), t.Name())
+	require.NoError(t, err)
+
+	nsmURL := &url.URL{Scheme: "tcp", Host: anyPortLocalHost}
+	nsmEndpoint := endpoint.NewServer(ctx, "nsm-endpoint", authorize.NewServer(), tokenGenerator, &fakeNSM{})
+	endpoint.Serve(ctx, nsmURL, nsmEndpoint)
+
+	t.Logf("NSMgr address: %v", nsmURL.String())
+
+	xServer := xconnectns.NewServer(ctx,
+		"xconnectns-forwarder",
+		authorize.NewServer(), tokenGenerator, fakeVppClientConn(ctx, t, &fakeVppAgent{}), dir,
+		nil, nil, nsmURL, grpc.WithInsecure())
+
+	server := chain.NewNetworkServiceServer(xServer, checkcontext.NewServer(t, func(t *testing.T, ctx context.Context) {
+		config := vppagent.Config(ctx)
+		require.NotNil(t, config)
+		vppConfig := config.VppConfig
+		require.NotNil(t, config)
+		require.Empty(t, vppConfig.Interfaces)
+		require.Empty(t, vppConfig.XconnectPairs)
+	}))
+
+	_, err = server.Request(ctx, request(t))
+	require.NoError(t, err)
+}

--- a/pkg/networkservice/chains/xconnectns/server_test.go
+++ b/pkg/networkservice/chains/xconnectns/server_test.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -149,4 +150,7 @@ func TestDirectMemifCase(t *testing.T) {
 
 	_, err = server.Request(ctx, request(t))
 	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(dir, sourceSocketFile))
+	require.False(t, os.IsNotExist(err))
 }

--- a/pkg/networkservice/metrics/server.go
+++ b/pkg/networkservice/metrics/server.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/sirupsen/logrus"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
 
 	"go.ligato.io/vpp-agent/v3/proto/ligato/configurator"
 	vpp_interfaces "go.ligato.io/vpp-agent/v3/proto/ligato/vpp/interfaces"
@@ -50,7 +50,7 @@ func (s *metricsServer) Request(ctx context.Context, request *networkservice.Net
 
 	ifaces := conf.GetVppConfig().GetInterfaces()
 	if len(ifaces) == 0 {
-		logrus.Info("MetricsServer skipped: empty vppconfig interfaces")
+		log.Entry(ctx).Warn("vppconfig has no interfaces")
 		return next.Server(ctx).Request(ctx, request)
 	}
 

--- a/pkg/networkservice/metrics/server.go
+++ b/pkg/networkservice/metrics/server.go
@@ -26,6 +26,7 @@ import (
 	vpp_interfaces "go.ligato.io/vpp-agent/v3/proto/ligato/vpp/interfaces"
 
 	"github.com/golang/protobuf/ptypes/empty"
+
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/trace"
@@ -45,9 +46,7 @@ func (s *metricsServer) Request(ctx context.Context, request *networkservice.Net
 		return nil, errors.New("VPPAgent config is missing")
 	}
 	ifaces := conf.GetVppConfig().GetInterfaces()
-	if len(ifaces) == 0 {
-		return nil, errors.New("VPPAgent config should contain at least one interface")
-	}
+
 	index := request.GetConnection().GetPath().GetIndex()
 	conn, err := next.Server(ctx).Request(ctx, request)
 	if err == nil {

--- a/pkg/networkservice/metrics/server.go
+++ b/pkg/networkservice/metrics/server.go
@@ -45,7 +45,11 @@ func (s *metricsServer) Request(ctx context.Context, request *networkservice.Net
 	if conf == nil {
 		return nil, errors.New("VPPAgent config is missing")
 	}
+
 	ifaces := conf.GetVppConfig().GetInterfaces()
+	if len(ifaces) == 0 {
+		return next.Server(ctx).Request(ctx, request)
+	}
 
 	index := request.GetConnection().GetPath().GetIndex()
 	conn, err := next.Server(ctx).Request(ctx, request)

--- a/pkg/networkservice/metrics/server.go
+++ b/pkg/networkservice/metrics/server.go
@@ -22,6 +22,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"go.ligato.io/vpp-agent/v3/proto/ligato/configurator"
 	vpp_interfaces "go.ligato.io/vpp-agent/v3/proto/ligato/vpp/interfaces"
 
@@ -48,6 +50,7 @@ func (s *metricsServer) Request(ctx context.Context, request *networkservice.Net
 
 	ifaces := conf.GetVppConfig().GetInterfaces()
 	if len(ifaces) == 0 {
+		logrus.Info("MetricsServer skipped: empty vppconfig interfaces")
 		return next.Server(ctx).Request(ctx, request)
 	}
 


### PR DESCRIPTION
Should fix #359 
1. Changed position of directMemifServer in xconnectNSServer chain. Now `directmemif.NewServer()` was called after `connectioncontextkernel.NewServer()`
2. Added `directmemif.removeXConnect` to remove XConnectPairs from vppConfig, if client and endpoint use directmemif.
2. Removed empty vppconfig.Interfaces check in `metrics.metricsServer` Request method.  
3. Added unit test to `xconnectNSServer`