### PR TITLE
VPP configuration

### DIFF
--- a/pkg/tools/vppagent/options.go
+++ b/pkg/tools/vppagent/options.go
@@ -23,12 +23,15 @@ const (
 	DefaultGrpcPort = 9111
 	// DefaultHTTPPort - Default value for HTTP port
 	DefaultHTTPPort = 9191
+	// DefaultAdditionalVppConf - Default value for additional VPP configuration
+	DefaultAdditionalVppConf = ""
 )
 
 type option struct {
-	rootDir  string
-	grpcPort int
-	httpPort int
+	rootDir           string
+	grpcPort          int
+	httpPort          int
+	additionalVPPConf string
 }
 
 // Option - Option for use with vppagent.Start(...)
@@ -52,5 +55,12 @@ func WithGrpcPort(grpcPort int) Option {
 func WithHTTPPort(httpPort int) Option {
 	return func(opt *option) {
 		opt.httpPort = httpPort
+	}
+}
+
+// WithAdditionalVPPConf - append an additional configuration to vpp.conf
+func WithAdditionalVPPConf(additionalVPPConf string) Option {
+	return func(opt *option) {
+		opt.additionalVPPConf = additionalVPPConf
 	}
 }

--- a/pkg/tools/vppagent/start.go
+++ b/pkg/tools/vppagent/start.go
@@ -41,9 +41,10 @@ func StartAndDialContext(ctx context.Context, opts ...Option) (vppagentCC grpc.C
 	errCh = make(chan error, 5)
 
 	o := &option{
-		rootDir:  DefaultRootDir,
-		grpcPort: DefaultGrpcPort,
-		httpPort: DefaultHTTPPort,
+		rootDir:           DefaultRootDir,
+		grpcPort:          DefaultGrpcPort,
+		httpPort:          DefaultHTTPPort,
+		additionalVPPConf: DefaultAdditionalVppConf,
 	}
 	for _, opt := range opts {
 		opt(o)
@@ -110,7 +111,7 @@ func StartAndDialContext(ctx context.Context, opts ...Option) (vppagentCC grpc.C
 
 func writeDefaultConfigFiles(ctx context.Context, o *option) error {
 	configFiles := map[string]string{
-		vppConfFilename:           fmt.Sprintf(vppConfContents, o.rootDir),
+		vppConfFilename:           fmt.Sprintf(vppConfContents, o.rootDir, o.additionalVPPConf),
 		vppAgentGoVPPConfFilename: fmt.Sprintf(vppAgentGoVPPConfContents, o.rootDir),
 		vppAgentGrpcConfFilename:  fmt.Sprintf(vppAgentGrpcConfContents, o.grpcPort),
 		vppAgentHTTPConfFilename:  fmt.Sprintf(vppAgentHTTPConfContents, o.httpPort),

--- a/pkg/tools/vppagent/vpp.conf.go
+++ b/pkg/tools/vppagent/vpp.conf.go
@@ -178,5 +178,12 @@ cpu {
 plugins {
 	plugin dpdk_plugin.so { disable }
 }
+
+buffers {
+	buffers-per-numa 65535
+}
+
+# User-provided changes below this line
+%[2]s
 `
 )


### PR DESCRIPTION
* Add `buffers-per-numa 65535` to the default VPP configuration.
* Add `WithAdditionalVPPConf` option. With this option it is possible for the user to override the default `buffers-per-numa` or any other default value.

Related cmd-forwarder-vppagent PR: https://github.com/networkservicemesh/cmd-forwarder-vppagent/pull/225