### PR TITLE
Bump pull-request-action to v1.0.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     env:
-      GOLANGCI_LINT_CONTAINER: golangci/golangci-lint:v1.23.2
+      GOLANGCI_LINT_CONTAINER: golangci/golangci-lint:v1.32.2
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/pr-for-updates.yaml
+++ b/.github/workflows/pr-for-updates.yaml
@@ -16,7 +16,7 @@ jobs:
           echo ${PULL_REQUEST_BODY}
           echo "::set-env name=PULL_REQUEST_BODY::${PULL_REQUEST_BODY}"
       - name: pull-request-action
-        uses: vsoch/pull-request-action@1.0.6
+        uses: vsoch/pull-request-action@1.0.12
         env:
           GITHUB_TOKEN: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
           BRANCH_PREFIX: "update/"

--- a/.github/workflows/pr-for-updates.yaml
+++ b/.github/workflows/pr-for-updates.yaml
@@ -14,7 +14,7 @@ jobs:
         run: |
           PULL_REQUEST_BODY=$(git log -1)
           echo ${PULL_REQUEST_BODY}
-          echo "::set-env name=PULL_REQUEST_BODY::${PULL_REQUEST_BODY}"
+          echo PULL_REQUEST_BODY=${PULL_REQUEST_BODY} >> $GITHUB_ENV
       - name: pull-request-action
         uses: vsoch/pull-request-action@1.0.12
         env:


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

This PR fixes
```
Error: Unable to process command '::set-env name=PULL_REQUEST_NUMBER::null' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Error: Unable to process command '::set-env name=PULL_REQUEST_RETURN_CODE::0' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Error: Unable to process command '::set-env name=PULL_REQUEST_URL::null' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

```